### PR TITLE
Different limit policy for major and minor versions and Intermediate versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.alfresco.extension</groupId>
-	<artifactId>max-version-policy-${project.version}</artifactId>
+	<artifactId>max-version-policy</artifactId>
 	<version>0.0.9-SNAPSHOT</version>
 	<packaging>amp</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.alfresco.extension</groupId>
 	<artifactId>max-version-policy</artifactId>
-	<version>0.0.9-SNAPSHOT</version>
+	<version>0.0.10-SNAPSHOT</version>
 	<packaging>amp</packaging>
 
 	<properties>

--- a/src/main/amp/config/alfresco/module/org.alfresco.extension.versioning/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/org.alfresco.extension.versioning/alfresco-global.properties
@@ -1,1 +1,9 @@
-maxVersions=10
+# number of minor versions to be kept or 0 to keep all
+maxVersionPolicy.maxMinorVersions=5
+# if not zero will be kept intermediate minor versions wich are multiple of the specified value (should be lesser than maxMinorVersions) or 0 to disable
+# 	eg. if we have versions from 1.0 to 1.4 (with maxMinorVersions=5 and keepIntermediateMinorVersions=5) and we create vesion 1.5, 1.1 will be deleted instead of 1.0
+maxVersionPolicy.keepIntermediateMinorVersions=5
+# number of major versions to be kept or 0 to keep all
+maxVersionPolicy.maxMajorVersions=5
+# like keepIntermediateMinorVersions but for major ones
+maxVersionPolicy.keepIntermediateMajorVersions=5

--- a/src/main/amp/config/alfresco/module/org.alfresco.extension.versioning/module-context.xml
+++ b/src/main/amp/config/alfresco/module/org.alfresco.extension.versioning/module-context.xml
@@ -11,8 +11,17 @@
                 <ref bean="VersionService" />
             </property>
             <!-- The max number of versions per versioned node -->
-            <property name="maxVersions">
-                <value>${maxVersions}</value>
+            <property name="maxMinorVersions">
+                <value>${maxVersionPolicy.maxMinorVersions}</value>
+            </property>
+            <property name="keepIntermediateMinorVersions">
+                <value>${maxVersionPolicy.keepIntermediateMinorVersions}</value>
+            </property>
+            <property name="maxMajorVersions">
+                <value>${maxVersionPolicy.maxMajorVersions}</value>
+            </property>
+            <property name="keepIntermediateMajorVersions">
+                <value>${maxVersionPolicy.keepIntermediateMajorVersions}</value>
             </property>
         </bean>
     

--- a/src/main/amp/module.properties
+++ b/src/main/amp/module.properties
@@ -1,6 +1,6 @@
 #Alfresco MaxVersion Policy module properties
 module.id=org.alfresco.MaxVersionPolicy
-module.version=0.0.8
+module.version=${project.version}
 module.buildnumber=SNAPSHOT
 module.title=Alfresco MaxVersion Policy
 module.description=This module adds a policy allowing you to set the max number of versions for a versioned node

--- a/src/main/amp/module.properties
+++ b/src/main/amp/module.properties
@@ -1,5 +1,5 @@
 #Alfresco MaxVersion Policy module properties
-module.id=org.alfresco.extension.version
+module.id=org.alfresco.MaxVersionPolicy
 module.version=0.0.8
 module.buildnumber=SNAPSHOT
 module.title=Alfresco MaxVersion Policy

--- a/src/main/java/org/alfresco/extension/versioning/MaxVersionPolicy.java
+++ b/src/main/java/org/alfresco/extension/versioning/MaxVersionPolicy.java
@@ -119,6 +119,17 @@ public class MaxVersionPolicy
 
 	@Override
 	public void afterCreateVersion(NodeRef versionableNode, Version version) {
+		try {
+			doAfterCreateVersion(versionableNode, version);
+		} catch (Throwable e) {
+			// if any error occur: log the error and carry on (we should not
+			// block the creation of a new version just becouse ve fail in
+			// removing older ones)
+			logger.error("An error happen:", e);
+		}
+	}
+
+	public void doAfterCreateVersion(NodeRef versionableNode, Version version) {
 		// If maxVersions is zero, consider policy to be disabled
 		if (maxMajorVersions == 0 && maxMinorVersions == 0) {
 			logger.debug("maxMajorVersions and maxMinorVersions is set to zero, consider policy to be disabled");
@@ -151,7 +162,7 @@ public class MaxVersionPolicy
 						+ versionHistory.getAllVersions().size() + ") "
 						+ sb.toString());
 			}
-			
+
 			List<Version> majorVersions = new LinkedList<>();
 			List<Version> minorVersions = new LinkedList<>();
 

--- a/src/main/java/org/alfresco/extension/versioning/MaxVersionPolicy.java
+++ b/src/main/java/org/alfresco/extension/versioning/MaxVersionPolicy.java
@@ -18,6 +18,11 @@
 
 package org.alfresco.extension.versioning;
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
 
 import org.alfresco.repo.policy.Behaviour;
 import org.alfresco.repo.policy.JavaBehaviour;
@@ -28,6 +33,7 @@ import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.version.Version;
 import org.alfresco.service.cmr.version.VersionHistory;
 import org.alfresco.service.cmr.version.VersionService;
+import org.alfresco.service.cmr.version.VersionType;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.service.namespace.QName;
 import org.apache.log4j.Logger;
@@ -44,73 +50,199 @@ public class MaxVersionPolicy
     implements AfterCreateVersionPolicy
 {
 
-    private Logger          logger = Logger.getLogger(MaxVersionPolicy.class);
+	private Logger logger = Logger.getLogger(MaxVersionPolicy.class);
 
-    private PolicyComponent policyComponent;
-    private VersionService  versionService;
+	private PolicyComponent policyComponent;
+	private VersionService versionService;
 
-    // max number of versions per version node
-    private int             maxVersions;
+	// max number of versions per version node
+	private int maxMinorVersions;
+	private int keepIntermediateMinorVersions;
+	private int maxMajorVersions;
+	private int keepIntermediateMajorVersions;
 
-    private Behaviour       afterCreateVersion;
 
 
     public void setPolicyComponent(PolicyComponent policyComponent)
     {
-        this.policyComponent = policyComponent;
-    }
+		this.policyComponent = policyComponent;
+	}
 
 
     public void setVersionService(VersionService versionService)
     {
-        this.versionService = versionService;
-    }
+		this.versionService = versionService;
+	}
 
+	public void setMaxMajorVersions(int maxMajorVersions) {
+		this.maxMajorVersions = maxMajorVersions;
+	}
 
-    public void setMaxVersions(int maxVersions)
-    {
-        this.maxVersions = maxVersions;
-    }
+	public void setKeepIntermediateMajorVersions(
+			int keepIntermediateMajorVersions) {
+		this.keepIntermediateMajorVersions = keepIntermediateMajorVersions;
+	}
 
+	public void setMaxMinorVersions(int maxMinorVersions) {
+		this.maxMinorVersions = maxMinorVersions;
+	}
 
-    public void init()
-    {
-        logger.debug("MaxVersions is set to: " + maxVersions);
-        this.afterCreateVersion = new JavaBehaviour(this, "afterCreateVersion", NotificationFrequency.TRANSACTION_COMMIT);
-        this.policyComponent.bindClassBehaviour(QName.createQName(NamespaceService.ALFRESCO_URI, "afterCreateVersion"), MaxVersionPolicy.class, this.afterCreateVersion);
-    }
+	public void setKeepIntermediateMinorVersions(
+			int keepIntermediateMinorVersions) {
+		this.keepIntermediateMinorVersions = keepIntermediateMinorVersions;
+	}
 
+	public void init() {
+		logger.debug("maxMajorVersions is set to: " + maxMajorVersions);
+		logger.debug("keepIntermediateMajorVersions is set to: "
+				+ keepIntermediateMajorVersions);
+		logger.debug("maxMinorVersions is set to: " + maxMinorVersions);
+		logger.debug("keepIntermediateMinorVersions is set to: "
+				+ keepIntermediateMinorVersions);
+		Behaviour afterCreateVersion = new JavaBehaviour(this,
+				"afterCreateVersion", NotificationFrequency.TRANSACTION_COMMIT);
+		this.policyComponent.bindClassBehaviour(QName.createQName(
+				NamespaceService.ALFRESCO_URI, "afterCreateVersion"),
+				MaxVersionPolicy.class, afterCreateVersion);
 
-    @Override
-    public void afterCreateVersion(NodeRef versionableNode, Version version)
-    {
-        VersionHistory versionHistory = versionService.getVersionHistory(versionableNode);
+		if (keepIntermediateMajorVersions > maxMajorVersions) {
+			logger.warn("keepIntermediateMajorVersions shoud me lesser or equal of maxMajorVersions: maxMajorVersions will be used ("
+					+ maxMajorVersions + ")");
+			keepIntermediateMajorVersions = maxMajorVersions;
+		}
+		if (keepIntermediateMinorVersions > maxMinorVersions) {
+			logger.warn("keepIntermediateMinorVersions shoud me lesser or equal of maxMinorVersions: maxMinorVersions will be used ("
+					+ maxMinorVersions + ")");
+			keepIntermediateMinorVersions = maxMinorVersions;
+		}
+	}
 
-        // If maxVersions is zero, consider policy to be disabled
-        if (maxVersions == 0)
-        {
-            logger.debug("maxVersions is set to zero, consider policy to be disabled");
-            return;
-        }
+	@Override
+	public void afterCreateVersion(NodeRef versionableNode, Version version) {
+		// If maxVersions is zero, consider policy to be disabled
+		if (maxMajorVersions == 0 && maxMinorVersions == 0) {
+			logger.debug("maxMajorVersions and maxMinorVersions is set to zero, consider policy to be disabled");
+			return;
+		}
 
-        if (versionHistory != null)
-        {
-            logger.debug("Current number of versions: " + versionHistory.getAllVersions().size());
-            logger.debug("least recent/root version: " + versionHistory.getRootVersion().getVersionLabel());
+		VersionHistory versionHistory = versionService
+				.getVersionHistory(versionableNode);
 
-            // If the current number of versions in the VersionHistory is greater
-            // than the maxVersions limit, remove the root/least recent version
-            // (Remove all version in while cycle since we can have legacy nodes with long history created before the policy was applied.)
-            while (versionHistory.getAllVersions().size() > maxVersions)
-            {
-                logger.debug("Removing Version: " + versionHistory.getRootVersion().getVersionLabel());
-                versionService.deleteVersion(versionableNode, versionHistory.getRootVersion());
-                versionHistory = versionService.getVersionHistory(versionableNode);
-            }
-        }
-        else
-        {
-            logger.debug("versionHistory does not exist");
-        }
-    }
+		if (versionHistory != null) {
+
+			Collection<Version> versions = versionHistory.getAllVersions();
+			if (logger.isDebugEnabled()) {
+				if (versions.size() > 0) {
+					if (!versions.iterator().next()
+							.equals(versionHistory.getHeadVersion())) {
+						throw new IllegalStateException(
+								"The first version returned by versionHistory.getAllVersions() should be the latest.");
+					}
+				}
+				StringBuilder sb = new StringBuilder();
+				Iterator<Version> it = versions.iterator();
+				while (it.hasNext()) {
+					sb.append(it.next().getVersionLabel());
+					if (it.hasNext()) {
+						sb.append(", ");
+					}
+				}
+				logger.debug("Current versions: ("
+						+ versionHistory.getAllVersions().size() + ") "
+						+ sb.toString());
+			}
+			
+			List<Version> majorVersions = new LinkedList<>();
+			List<Version> minorVersions = new LinkedList<>();
+
+			for (Version v : versions) {
+				switch (v.getVersionType()) {
+				case MAJOR:
+					majorVersions.add(v);
+					break;
+				case MINOR:
+					minorVersions.add(v);
+					break;
+				default:
+					throw new IllegalStateException(
+							"a version shoul be Major or Minor");
+				}
+			}
+
+			enforceMaxVersions(versionableNode, VersionType.MAJOR,
+					majorVersions, maxMajorVersions,
+					keepIntermediateMajorVersions);
+			enforceMaxVersions(versionableNode, VersionType.MINOR,
+					minorVersions, maxMinorVersions,
+					keepIntermediateMinorVersions);
+		} else {
+			logger.debug("versionHistory does not exist");
+		}
+	}
+
+	private void enforceMaxVersions(NodeRef versionableNode,
+			VersionType versionType, List<Version> versions, int maxVersions,
+			int keepIntermediateVersions) {
+		if (maxVersions > 0 && versions.size() > maxVersions) {
+			Version toBeRemoved = null;
+
+			while (versions.size() > maxVersions) {
+				if (keepIntermediateVersions <= 0) {
+					// if we do not need to keep intermediate vesions we simply
+					// remove the last one (the older)
+					toBeRemoved = versions.get(versions.size() - 1);
+				} else {
+					// skip the first version (the most recent one) that sould
+					// not be removed
+					// start from the end of the list (the oldest version)
+					ListIterator<Version> it = versions.subList(1,
+							versions.size()).listIterator(versions.size() - 1);
+					// until we found the first version we can remove (scanning
+					// from the oldest to the newest ones)
+					while (it.hasPrevious()) {
+						Version version = it.previous();
+						if (toBeRemoved == null) {
+							// if we dont find another version we can safely
+							// rmove, we remove the last one
+							toBeRemoved = version;
+						}
+						int versionNumber;
+						switch (versionType) {
+						case MAJOR:
+							// the number before the dot (2.3 -> 2)
+							versionNumber = Integer.parseInt(version
+									.getVersionLabel().split("\\.")[0]);
+							break;
+						case MINOR:
+						default:
+							// the number after the dot (2.3 -> 3)
+							versionNumber = Integer.parseInt(version
+									.getVersionLabel().split("\\.")[1]);
+							break;
+						}
+						// if the module is 0 we must try to keep this version
+						if (versionNumber % keepIntermediateVersions == 0) {
+							// this version should be kept, continue to search
+							continue;
+						} else {
+							// this is the first version we can remove safely
+							toBeRemoved = version;
+							break;
+						}
+					}
+				}
+
+				if (toBeRemoved != null) {
+					logger.debug("Removing Version: "
+							+ toBeRemoved.getVersionLabel());
+					versionService.deleteVersion(versionableNode, toBeRemoved);
+					versions.remove(toBeRemoved);
+					toBeRemoved = null;
+				} else {
+					throw new IllegalStateException(
+							"Unable to find a version to be removed");
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Hi,

i've added some functionality you may like:

```
# number of minor versions to be kept or 0 to keep all
maxVersionPolicy.maxMinorVersions=5
# if not zero will be kept intermediate minor versions wich are multiple of the specified value (should be lesser than maxMinorVersions) or 0 to disable
# 	eg. if we have versions from 1.0 to 1.4 (with maxMinorVersions=5 and keepIntermediateMinorVersions=5) and we create vesion 1.5, 1.1 will be deleted instead of 1.0
maxVersionPolicy.keepIntermediateMinorVersions=5
# number of major versions to be kept or 0 to keep all
maxVersionPolicy.maxMajorVersions=5
# like keepIntermediateMinorVersions but for major ones
maxVersionPolicy.keepIntermediateMajorVersions=5 
```

Please take a look; and feel free to merge or cherry pick

I've changed the moduleId, so, if you pick that change remember to first uninstall the previous module before installing this it they will conflict